### PR TITLE
mod: Replaced sleep statements with blocking on task queues

### DIFF
--- a/indi_allsky/image.py
+++ b/indi_allsky/image.py
@@ -174,10 +174,9 @@ class ImageWorker(Process):
         #raise Exception('Test exception handling in worker')
 
         while True:
-            time.sleep(0.05)  # sleep every loop
 
             try:
-                i_dict = self.image_q.get_nowait()
+                i_dict = self.image_q.get(block=True)
             except queue.Empty:
                 continue
 

--- a/indi_allsky/uploader.py
+++ b/indi_allsky/uploader.py
@@ -53,10 +53,9 @@ class FileUploader(Process):
         #raise Exception('Test exception handling in worker')
 
         while True:
-            time.sleep(0.7)  # sleep every loop
 
             try:
-                u_dict = self.upload_q.get_nowait()
+                u_dict = self.upload_q.get(block=True)
             except queue.Empty:
                 continue
 

--- a/indi_allsky/video.py
+++ b/indi_allsky/video.py
@@ -98,10 +98,9 @@ class VideoWorker(Process):
         #raise Exception('Test exception handling in worker')
 
         while True:
-            time.sleep(1.9)  # sleep every loop
 
             try:
-                v_dict = self.video_q.get_nowait()
+                v_dict = self.video_q.get(block=True)
             except queue.Empty:
                 continue
 


### PR DESCRIPTION
Task workers currently spinlock while waiting for new tasks, causing wasted cycles while tasks are intermittent. Introducing blocking allows more efficient waiting by the workers between tasks. Saw a noticeable improvement of CPU usage when tested against my current allsky camera.